### PR TITLE
Added WaveFormular enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ All basic waves are already supported, plus customized waves & some pre-defined 
 
 ## Features
 
-* Creating a sine wave.
-* Creating a stack of sine waves.
-* Combine multiple sine waves together.
-* This package use clipping to achieve wave effect so theoretically you can apply it to any widget. For example, an AppBar with a wave on the bottom.
+- Creating a sine wave.
+- Creating a stack of sine waves.
+- Combine multiple sine waves together.
+- This package use clipping to achieve wave effect so theoretically you can apply it to any widget. For example, an AppBar with a wave on the bottom.
 
 ## Getting started
 
@@ -45,7 +45,7 @@ Example of a sinusoidal:
 ```dart
 Sinusoidal(
   model: const SinusoidalModel(
-    travelling: true,
+    formular: WaveFormular.standing,
     amplitude: 25,
     waves: 2.5,
     frequency: 1.5,
@@ -71,7 +71,7 @@ Sinusoidals(
   builder: (context, index) {
     return SinusoidalItem(
       model: SinusoidalModel(
-        travelling: true,
+        formular: WaveFormular.travelling,
         amplitude: _amplitude,
         waves: _waves,
         translate: 5.0 * (index + 1),

--- a/example/main.dart
+++ b/example/main.dart
@@ -45,7 +45,7 @@ class _SinusoidalsDemo extends StatelessWidget {
           builder: (context, index) {
             return SinusoidalItem(
               model: SinusoidalModel(
-                standing: true,
+                formular: WaveFormular.standing,
                 amplitude: _amplitude,
                 waves: _waves,
                 translate: 5.0 * (index + 1),
@@ -65,7 +65,7 @@ class _SinusoidalsDemo extends StatelessWidget {
           builder: (context, index) {
             return SinusoidalItem(
               model: SinusoidalModel(
-                travelling: true,
+                formular: WaveFormular.travelling,
                 amplitude: _amplitude,
                 waves: _waves,
                 translate: 5.0 * (index + 1),
@@ -119,7 +119,7 @@ class _SinusoidalDemo extends StatelessWidget {
         const SizedBox(height: 50),
         Sinusoidal(
           model: const SinusoidalModel(
-            standing: true,
+            formular: WaveFormular.standing,
             translate: 5.0,
             amplitude: 25,
             waves: 2,
@@ -133,7 +133,7 @@ class _SinusoidalDemo extends StatelessWidget {
         const SizedBox(height: 50),
         Sinusoidal(
           model: const SinusoidalModel(
-            travelling: true,
+            formular: WaveFormular.travelling,
             amplitude: 25,
             waves: 2.5,
             frequency: 0.5,


### PR DESCRIPTION
This PR introduces WaveFormular enum for the SinusoidalModel because the old way I think was confusing for developers to understand which formula was going to be used.

This is approach has a cleaner implementation and checking for its current value it's easier to read.

Also, I formatted the code with Flutter's default formatter so the code looks cleaner.